### PR TITLE
Deprecate flydehq namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   
 [![Official Website](https://img.shields.io/badge/Official%20Website-flyde.dev-blue?style=flat&logo=world&logoColor=white)](https://flyde.dev.com)
 [![Discord Follow](https://dcbadge.vercel.app/api/server/x7t4tjZQP8?style=flat)](https://discord.com/invite/x7t4tjZQP8)
-[![GitHub Repo stars](https://img.shields.io/github/stars/flydehq/flyde?style=social)](https://github.com/flydehq/flyde)
+[![GitHub Repo stars](https://img.shields.io/github/stars/flydelabs/flyde?style=social)](https://github.com/flydelabs/flyde)
 [![@FlydeDev](https://img.shields.io/twitter/follow/FlydeDev?style=social)](https://twitter.com/FlydeDev)
 
 <strong>VSCode Extension ✔️</strong> · <strong>Runtime Library ✔️</strong> · <strong>Integrates with Existing Code ✔️</strong>
@@ -23,7 +23,7 @@
 <br/>
 </div>
 
-![Flyde example](https://github.com/FlydeHQ/flyde-vscode/raw/main/media/walkthrough/run-flow.gif)
+![Flyde example](https://github.com/flydelabs/flyde-vscode/raw/main/media/walkthrough/run-flow.gif)
 
 ## Features
 

--- a/examples/dad-jokes-cli/package.json
+++ b/examples/dad-jokes-cli/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.2",
   "license": "MIT",
   "main": "dist/cli.ts",
-  "homepage": "https://github.com/FlydeHQ/flyde/tree/main/examples/dad-jokes-cli",
+  "homepage": "https://github.com/flydelabs/flyde/tree/main/examples/dad-jokes-cli",
   "packageManager": "pnpm@8.3.1",
   "bin": {
     "dad-joke": "dist/cli.js"

--- a/website/blog/2023-01-22-introducing-flyde/index.md
+++ b/website/blog/2023-01-22-introducing-flyde/index.md
@@ -74,7 +74,7 @@ It has some simple examples that showcase the visual editor, and what building a
 
 The next step is to the checkout the tutorials section of this site to learn how to integrate Flyde into real-world projects
 
-If you've read so far I'd appreciate showing support by [starring the project](https://www.github.com/flydehq/flyde) and sending any feedback or comment via a GitHub issue or [Flyde's Discord channel](https://discord.com/invite/x7t4tjZQP8)
+If you've read so far I'd appreciate showing support by [starring the project](https://www.github.com/flydelabs/flyde) and sending any feedback or comment via a GitHub issue or [Flyde's Discord channel](https://discord.com/invite/x7t4tjZQP8)
 
 Thanks and stay tuned for more blog posts!
 

--- a/website/docs/Tutorials/code-parts/index.md
+++ b/website/docs/Tutorials/code-parts/index.md
@@ -113,4 +113,4 @@ Before moving on to the next tutorial, I highly recommend you to try tinkering w
 
 ---
 
-If you have any feedback or issue please open a [Github issue](https://github.com/FlydeHQ/flyde/issues/new) or ping us on Discord.
+If you have any feedback or issue please open a [Github issue](https://github.com/flydelabs/flyde/issues/new) or ping us on Discord.

--- a/website/docs/Tutorials/hello-world-with-flyde/index.md
+++ b/website/docs/Tutorials/hello-world-with-flyde/index.md
@@ -8,7 +8,7 @@ This tutorial will guide you step-by-step into creating an "Hello world" program
 
 This is how the end result should look like:
 ![./hello-world-result.gif](./hello-world-final-result.gif)
-Resulting code can be in the [examples folder](https://github.com/FlydeHQ/flyde/tree/main/examples/hello-flyde).
+Resulting code can be in the [examples folder](https://github.com/flydelabs/flyde/tree/main/examples/hello-flyde).
 
 ## What you'll need
 
@@ -122,4 +122,4 @@ Before moving on to the next tutorial, I highly recommend you to try tinkering w
 
 ---
 
-If you have any feedback or issue please open a [Github issue](https://github.com/FlydeHQ/flyde/issues/new) or ping us on Discord.
+If you have any feedback or issue please open a [Github issue](https://github.com/flydelabs/flyde/issues/new) or ping us on Discord.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -66,7 +66,7 @@ const config = {
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: "flydehq", // Usually your GitHub org/user name.
+  organizationName: "flydelabs", // Usually your GitHub org/user name.
   projectName: "flyde", // Usually your resolvedNodes name.
   deploymentBranch: "website",
   trailingSlash: true,
@@ -156,11 +156,11 @@ const config = {
             label: "VSCode Extension",
           },
           {
-            href: "https://github.com/FlydeHQ/flyde/tree/main/examples",
+            href: "https://github.com/flydelabs/flyde/tree/main/examples",
             label: "Examples",
           },
           {
-            href: "https://github.com/flydehq/flyde",
+            href: "https://github.com/flydelabs/flyde",
             label: "GitHub",
             position: "right",
           },
@@ -208,7 +208,7 @@ const config = {
               },
               {
                 label: "GitHub",
-                href: "https://github.com/flydehq/flyde",
+                href: "https://github.com/flydelabs/flyde",
               },
             ],
           },

--- a/website/src/pages/_hero-example/HeroExample.tsx
+++ b/website/src/pages/_hero-example/HeroExample.tsx
@@ -61,7 +61,7 @@ export const HeroExample: React.FC = () => {
         <span className="gh-stars-wrapper">
           <iframe
             className="gh-stars-frame"
-            src="https://ghbtns.com/github-btn.html?user=flydehq&amp;repo=flyde&amp;type=star&amp;count=true&amp;size=large"
+            src="https://ghbtns.com/github-btn.html?user=flydelabs&amp;repo=flyde&amp;type=star&amp;count=true&amp;size=large"
             width={160}
             height={30}
             title="GitHub Stars"

--- a/website/src/pages/playground/_PlaygroundTemplate/PlaygroundTemplate.tsx
+++ b/website/src/pages/playground/_PlaygroundTemplate/PlaygroundTemplate.tsx
@@ -218,7 +218,7 @@ export const PlaygroundTemplate: React.FC<PlaygroundTemplateProps> = (
                   <span className="star-wrapper">
                     <iframe
                       className="gh-stars-frame"
-                      src="https://ghbtns.com/github-btn.html?user=flydehq&amp;repo=flyde&amp;type=star&amp;count=true&amp;size=small"
+                      src="https://ghbtns.com/github-btn.html?user=flydelabs&amp;repo=flyde&amp;type=star&amp;count=true&amp;size=small"
                       width={100}
                       height={20}
                       title="GitHub Stars"


### PR DESCRIPTION
rename org name and all the links from `flydehq` to `flydelabs`

* even thogh github will redirect `https://github.com/flydehq/flyde` to `https://github.com/flydelabs/flyde` it won't do it for `https://github.com/flydehq`
* also better so seo